### PR TITLE
fix: 修复空调没有湿度传感器时，climate实体显示湿度0的问题

### DIFF
--- a/custom_components/haier/climate.py
+++ b/custom_components/haier/climate.py
@@ -62,7 +62,7 @@ class HaierClimate(HaierAbstractEntity, ClimateEntity):
         if 'indoorTemperature' in self.coordinator.data:
             self._attr_current_temperature = float(self.coordinator.data['indoorTemperature'])
 
-        if 'indoorHumidity' in self.coordinator.data:
+        if 'indoorHumidity' in self.coordinator.data and self.coordinator.data['indoorHumidity'] != 0:
             self._attr_current_humidity = float(self.coordinator.data['indoorHumidity'])
 
         self._attr_target_temperature = float(self.coordinator.data['targetTemperature'])

--- a/custom_components/haier/climate.py
+++ b/custom_components/haier/climate.py
@@ -62,7 +62,7 @@ class HaierClimate(HaierAbstractEntity, ClimateEntity):
         if 'indoorTemperature' in self.coordinator.data:
             self._attr_current_temperature = float(self.coordinator.data['indoorTemperature'])
 
-        if 'indoorHumidity' in self.coordinator.data and self.coordinator.data['indoorHumidity'] != 0:
+        if 'indoorHumidity' in self.coordinator.data and float(self.coordinator.data['indoorHumidity']) != 0:
             self._attr_current_humidity = float(self.coordinator.data['indoorHumidity'])
 
         self._attr_target_temperature = float(self.coordinator.data['targetTemperature'])


### PR DESCRIPTION
有些空调没有湿度传感器，湿度数据为0，所以根据湿度是否为0判断是否在climate实体显示湿度数据。