### PR TITLE
调整 README 中的 HACS 快速安装按钮位置

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@
 - Climate (Beta)
 
 ## 安装
-下载并复制`custom_components/haier`文件夹到HomeAssistant根目录下的`custom_components`文件夹即可完成安装
+
+方法1：下载并复制`custom_components/haier`文件夹到HomeAssistant根目录下的`custom_components`文件夹即可完成安装
+
+方法2：已经安装了HACS，可以点击按钮快速安装 [![通过HACS添加集成](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=banto6&repository=haier&category=integration)
 
 ## 配置
 
 配置 > 设备与服务 >  集成 >  添加集成 > 搜索`haier`
 
 或者点击: [![添加集成](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=haier)
-
-已经安装了HACS，可以点击：[![通过HACS添加集成](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=banto6&repository=haier&category=integration)
 
 ## 调试
 在`configuration.yaml`中加入以下配置来打开调试日志。


### PR DESCRIPTION
对 https://github.com/banto6/haier/pull/51 的更新，将HACS快速安装按钮调整到合适的位置上。