### PR TITLE
修复因为windDirectionVertical不存在导致的climate实体不可用的问题

### DIFF
--- a/custom_components/haier/climate.py
+++ b/custom_components/haier/climate.py
@@ -184,12 +184,10 @@ class HaierClimate(HaierAbstractEntity, ClimateEntity):
 
     def _get_wind_direction_vertical(self) -> str:
         if self._attribute.ext['exist_multiple_vents']:
-            return self._attributes_data['windDirectionVerticalL']
-
-        return self._attributes_data['windDirectionVertical']
+            return self._attributes_data.get('windDirectionVerticalL', '0')
+        return self._attributes_data.get('windDirectionVertical', '0')
 
     def _get_wind_direction_horizontal(self) -> str:
         if self._attribute.ext['exist_multiple_vents']:
-            return self._attributes_data['windDirectionHorizontalL']
-
-        return self._attributes_data['windDirectionHorizontal']
+            return self._attributes_data.get('windDirectionHorizontalL', '0')
+        return self._attributes_data.get('windDirectionHorizontal', '0')


### PR DESCRIPTION
haier的中央空调climate实体不可用，查看报错日志为
```
Traceback (most recent call last):
File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
result = self.fn(*self.args, **self.kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/haier/entity.py", line 74, in data_callback
self._update_value()
File "/config/custom_components/haier/climate.py", line 91, in updatevalue
wind_direction_vertical = int(self._get_wind_direction_vertical())
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/haier/climate.py", line 189, in getwind_direction_vertical
return self._attributes_data['windDirectionVertical']
~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'windDirectionVertical'
```
应该就是因为windDirectionVertical不存在导致的，修改了代码兼容了这种不存在的场景。