### PR TITLE
use `async_forward_entry_setups`

### DIFF
--- a/custom_components/haier/__init__.py
+++ b/custom_components/haier/__init__.py
@@ -56,10 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.async_create_background_task(client.listen_devices(devices, device_signal), 'haier-websocket')
     hass.data[DOMAIN]['signals'].append(device_signal)
 
-    for platform in SUPPORTED_PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, SUPPORTED_PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(entry_update_listener))
 


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

fixed warning in HA 2024.7