### PR TITLE
fix import

### DIFF
--- a/custom_components/haier/core/attribute.py
+++ b/custom_components/haier/core/attribute.py
@@ -2,7 +2,7 @@ import logging
 from abc import abstractmethod, ABC
 from typing import List
 
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import Platform, UnitOfTemperature, PERCENTAGE, UnitOfVolume, UnitOfEnergy
 


### PR DESCRIPTION
    NameError: name 'SensorStateClass' is not defined.