### PR TITLE
feat: 新增部分设备定时强制刷新

### DIFF
--- a/custom_components/haier/core/client.py
+++ b/custom_components/haier/core/client.py
@@ -32,6 +32,9 @@ GET_DEVICES_API = 'https://uws.haier.net/uds/v1/protected/deviceinfos'
 GET_WSS_GW_API = 'https://uws.haier.net/gmsWS/wsag/assign'
 GET_DIGITAL_MODEL_API = 'https://uws.haier.net/shadow/v1/devdigitalmodels'
 
+FORCE_REFRESH_PRODUCT_NAMES = [
+    'JSQ30-16R3BWU1'
+]
 
 def random_str(length: int = 32) -> str:
     return ''.join(random.choice('abcdef1234567890') for _ in range(length))
@@ -293,6 +296,18 @@ class HaierClient:
                         }
                     }))
 
+                    # 对于部分设备需要定时发送刷新命令以保持数据更新
+                    force_refresh_devices = [
+                        d for d in targetDevices
+                        if d.product_name in FORCE_REFRESH_PRODUCT_NAMES
+                    ]
+
+                    if force_refresh_devices:
+                        self._hass.async_create_background_task(
+                            self._send_force_refresh(ws, agClientId, heartbeat_signal, force_refresh_devices),
+                            'haier-wss-force-refresh'
+                        )
+
                     # 监听事件总线来的控制命令
                     async def control_callback(e):
                         await self._send_command(ws, agClientId, e.data['deviceId'], e.data['attributes'])
@@ -351,6 +366,21 @@ class HaierClient:
             await asyncio.sleep(60)
 
         _LOGGER.info("send heartbeat stopped")
+
+    @staticmethod
+    async def _send_force_refresh(ws, agClientId: str, event: threading.Event, devices: List[HaierDevice]):
+        while not event.is_set():
+            for device in devices:
+                try:
+                    await HaierClient._send_command(ws, agClientId, device.id, {'getAllProperty': 'getAllProperty'})
+
+                    _LOGGER.debug('Sent force refresh command to device: %s', device.id)
+                except:
+                    _LOGGER.exception('Failed to send force refresh to device: %s', device.id)
+
+            await asyncio.sleep(60)
+
+        _LOGGER.info("send force refresh stopped")
 
     async def _parse_message(self, msg):
         msg = json.loads(msg)


### PR DESCRIPTION
以我这台燃气热水器 JSQ30-16R3BWU1 为例，遇到了如下情况：
- 通电开机后一段时间（几小时或几天）内，会主动上报状态到云端，但是一段时间之后，就不再主动上报状态到云端，燃烧状态和水气用量都不再更新，包括官方的水气统计也是不完整的（每天都用热水，但是统计如下）
<details><summary>截图</summary>
<p>

<img width="370" height="213" alt="image" src="https://github.com/user-attachments/assets/a1ddbfc6-a49f-4105-95db-375b5b985e20" />


</p>
</details> 

- 只有在官方 App（不包括小程序）运行时/断电重启设备/HA（包括小程序）内主动对设备进行一次操作的时候，才会更新所有状态到云端

经过测试，发送 getAllProperty 命令可以强制让设备上报最新状态到云端，所以对这类上报懒惰的设备按照心跳的频率进行轮询，强制设备将最新状态上报到云端

我的海尔设备不多，只遇到了这个热水器有这种上报懒惰的问题，有人如果有遇到相同问题的设备，可进行测试