### PR TITLE
fix: 为洗碗机/洗衣机增加洗涤模式、分区洗、启动暂停的 Select 实体

### DIFF
--- a/custom_components/haier/core/attribute.py
+++ b/custom_components/haier/core/attribute.py
@@ -94,6 +94,24 @@ class V1SpecAttributeParser(HaierAttributeParser, ABC):
         if 'openDegree' in all_attribute_keys:
             yield self._parse_as_cover(attributes)
 
+        # 洗碗机/洗衣机：对只读LIST类型的洗涤模式属性，保留原Sensor作为状态读取，
+        # 同时额外生成Select实体用于在HA中切换模式
+        _control_attrs = {'washprog', 'partitionwashstatus', 'runningmode'}
+        for attr in attributes:
+            if attr['name'].lower() in _control_attrs \
+                    and equals_ignore_case(attr['valueRange']['type'], 'LIST'):
+                value_comparison_table = {}
+                for item in attr['valueRange']['dataList']:
+                    value_comparison_table[str(item['data'])] = item['desc']
+                    value_comparison_table[str(item['desc'])] = item['data']
+                yield HaierAttribute(
+                    attr['name'] + '_sel',
+                    attr['desc'],
+                    Platform.SELECT,
+                    {'options': [item['desc'] for item in attr['valueRange']['dataList']]},
+                    {'value_comparison_table': value_comparison_table, 'data_key': attr['name']}
+                )
+
 
     @staticmethod
     def _parse_as_sensor(attribute):

--- a/custom_components/haier/select.py
+++ b/custom_components/haier/select.py
@@ -32,11 +32,13 @@ class HaierSelect(HaierAbstractEntity, SelectEntity):
             raise ValueError('value_comparison_table must exist')
 
     def _update_value(self):
-        self._attr_current_option = self._get_value_from_comparison_table(self._attributes_data[self._attribute.key])
+        data_key = self._attribute.ext.get('data_key', self._attribute.key)
+        self._attr_current_option = self._get_value_from_comparison_table(self._attributes_data[data_key])
 
     def select_option(self, option: str) -> None:
+        data_key = self._attribute.ext.get('data_key', self._attribute.key)
         self._send_command({
-            self._attribute.key: self._get_value_from_comparison_table(option)
+            data_key: self._get_value_from_comparison_table(option)
         })
 
     def _get_value_from_comparison_table(self, value):


### PR DESCRIPTION
## 问题

海尔云端的部分 LIST 类型属性（如 `washProg`、`partitionwashstatus`、`runningMode`）被标记为只读，导致这些属性在 HA 中只能以 ENUM Sensor 形式出现，无法进行选择操作。用户无法在 HA 中切换洗涤程序、分区洗模式或启动/暂停洗碗机。

## 修改内容

### `core/attribute.py`
- 在 `parse_global` 中新增洗碗机/洗衣机模式属性的检测逻辑，使用大小写不敏感匹配（`washprog`、`partitionwashstatus`、`runningmode`）
- 对每个匹配的属性，额外生成一个 `Platform.SELECT` 类型的 `HaierAttribute`，key 加 `_sel` 后缀避免与 Sensor 的 unique_id 冲突
- Select 实体通过 `ext.data_key` 指向原始属性名，实现数据的读写

### `select.py`
- `_update_value` 和 `select_option` 方法增加对 `data_key` 的支持，优先使用 `data_key` 读取/写入属性数据
- 未设置 `data_key` 时回退到原有 `attribute.key` 行为，保证向后兼容

## 效果

以海尔洗碗机为例，改动后共存实体如下：

| 原 Sensor（保留，只读） | 新增 Select（可控） | 可选数量 |
|---|---|---|
| `sensor.xxx_washprog` 洗涤程序 | `select.xxx_washprog_sel` 洗涤程序 | 14 个 |
| `sensor.xxx_partitionwashstatus` 分区洗 | `select.xxx_partitionwashstatus_sel` 分区洗 | 3 个 |
| `sensor.xxx_runningmode` 运行状态 | `select.xxx_runningmode_sel` 运行状态 | 启动/暂停 |

## 测试

- [x] 原有 Sensor 实体正常工作
- [x] 新增 Select 实体显示正确选项并可选择
- [x] 选择后正确发送命令到海尔云端
- [x] 空调/热水器/窗帘等现有实体不受影响

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)