### PR TITLE
feat: Token来源可选，修复非默认来源的refresh_token刷新失败

### DIFF
--- a/custom_components/haier/__init__.py
+++ b/custom_components/haier/__init__.py
@@ -25,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN]['cancel_token_updater'] = await token_updater(hass, entry)
 
     account_cfg = AccountConfig(hass, entry)
-    client = HaierClient(hass, account_cfg.client_id, account_cfg.token)
+    client = HaierClient(hass, account_cfg.client_id, account_cfg.token, account_cfg.app_source)
 
     # 是否忽略设备离线状态，供实体在收到离线事件时判断是否保留最后状态
     hass.data[DOMAIN]['ignore_device_offline'] = account_cfg.ignore_device_offline
@@ -62,7 +62,7 @@ async def token_updater(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER.debug("try update token...")
 
         cfg = AccountConfig(hass, entry)
-        client = HaierClient(hass, cfg.client_id, cfg.token)
+        client = HaierClient(hass, cfg.client_id, cfg.token, cfg.app_source)
 
         token_valid = True
         try:

--- a/custom_components/haier/config_flow.py
+++ b/custom_components/haier/config_flow.py
@@ -9,13 +9,19 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.config_validation import multi_select
 
 from .const import DOMAIN, FILTER_TYPE_EXCLUDE, FILTER_TYPE_INCLUDE
-from .core.client import HaierClientException, HaierClient
+from .core.client import HaierClientException, HaierClient, APP_SOURCE_APP, APP_SOURCE_WXAPP, DEFAULT_APP_SOURCE
 from .core.config import AccountConfig, DeviceFilterConfig, EntityFilterConfig
 
 _LOGGER = logging.getLogger(__name__)
 
 CLIENT_ID = 'client_id'
 REFRESH_TOKEN = 'refresh_token'
+APP_SOURCE = 'app_source'
+
+APP_SOURCE_OPTIONS = {
+    APP_SOURCE_WXAPP: '微信小程序',
+    APP_SOURCE_APP: 'App',
+}
 
 class HaierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 2
@@ -25,10 +31,10 @@ class HaierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 # 根据refresh_token获取token
-                client = HaierClient(self.hass, user_input[CLIENT_ID], '')
+                client = HaierClient(self.hass, user_input[CLIENT_ID], '', user_input[APP_SOURCE])
                 token_info = await client.refresh_token(user_input[REFRESH_TOKEN])
                 # 获取用户信息
-                client = HaierClient(self.hass, user_input[CLIENT_ID], token_info.token)
+                client = HaierClient(self.hass, user_input[CLIENT_ID], token_info.token, user_input[APP_SOURCE])
                 user_info = await client.get_user_info()
 
                 return self.async_create_entry(title="Haier - {}".format(user_info['mobile']), data={
@@ -37,6 +43,7 @@ class HaierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         'token': token_info.token,
                         'refresh_token': token_info.refresh_token,
                         'expires_at': int(time.time()) + token_info.expires_in,
+                        'app_source': user_input[APP_SOURCE],
                         'default_load_all_entity': user_input['default_load_all_entity'],
                         'ignore_device_offline': user_input['ignore_device_offline']
                     }
@@ -51,6 +58,7 @@ class HaierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CLIENT_ID): str,
                     vol.Required(REFRESH_TOKEN): str,
+                    vol.Required(APP_SOURCE, default=DEFAULT_APP_SOURCE): vol.In(APP_SOURCE_OPTIONS),
                     vol.Required('default_load_all_entity', default=True): bool,
                     vol.Required('ignore_device_offline', default=False): bool,
                 }
@@ -92,16 +100,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             try:
                 # 根据refresh_token获取token
-                client = HaierClient(self.hass, user_input[CLIENT_ID], '')
+                client = HaierClient(self.hass, user_input[CLIENT_ID], '', user_input[APP_SOURCE])
                 token_info = await client.refresh_token(user_input[REFRESH_TOKEN])
                 # 获取用户信息
-                client = HaierClient(self.hass, user_input[CLIENT_ID], token_info.token)
+                client = HaierClient(self.hass, user_input[CLIENT_ID], token_info.token, user_input[APP_SOURCE])
                 user_info = await client.get_user_info()
 
                 cfg.client_id = user_input[CLIENT_ID]
                 cfg.token = token_info.token
                 cfg.refresh_token = token_info.refresh_token
                 cfg.expires_at = int(time.time()) + token_info.expires_in
+                cfg.app_source = user_input[APP_SOURCE]
                 cfg.default_load_all_entity = user_input['default_load_all_entity']
                 cfg.ignore_device_offline = user_input['ignore_device_offline']
                 cfg.save(user_info['mobile'])
@@ -119,6 +128,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Required(CLIENT_ID, default=cfg.client_id): str,
                     vol.Required(REFRESH_TOKEN, default=cfg.refresh_token): str,
+                    vol.Required(APP_SOURCE, default=cfg.app_source): vol.In(APP_SOURCE_OPTIONS),
                     vol.Required('default_load_all_entity', default=cfg.default_load_all_entity): bool,
                     vol.Required('ignore_device_offline', default=cfg.ignore_device_offline): bool,
                 }

--- a/custom_components/haier/core/client.py
+++ b/custom_components/haier/core/client.py
@@ -17,8 +17,19 @@ from .device import HaierDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-APP_ID = 'MB-SHEZJAPPWXXCX-0000'
-APP_KEY = '79ce99cc7f9804663939676031b8a427'
+# token来源客户端。refresh_token与签发它的appId绑定，用其他客户端的appId去刷新
+# 会返回 43005 授权异常或失败，所以此处须与token的来源客户端一致
+APP_SOURCE_WXAPP = 'wxapp'
+APP_SOURCE_APP = 'app'
+
+DEFAULT_APP_SOURCE = APP_SOURCE_WXAPP
+
+APP_SOURCES = {
+    # 微信小程序
+    APP_SOURCE_WXAPP: ('MB-SHEZJAPPWXXCX-0000', '79ce99cc7f9804663939676031b8a427'),
+    # App
+    APP_SOURCE_APP: ('MB-UZHSH-0001', '5dfca8714eb26e3a776e58a8273c8752'),
+}
 
 REFRESH_TOKEN_API = 'https://zj.haier.net/api-gw/oauthserver/account/v1/refreshToken'
 GET_USER_INFO_API = 'https://account-api.haier.net/v2/haier/userinfo'
@@ -90,9 +101,10 @@ class HaierClientException(Exception):
 
 class HaierClient:
 
-    def __init__(self, hass: HomeAssistant, client_id: str, token: str):
+    def __init__(self, hass: HomeAssistant, client_id: str, token: str, app_source: str = DEFAULT_APP_SOURCE):
         self._client_id = client_id
         self._token = token
+        self._app_id, self._app_key = APP_SOURCES.get(app_source, APP_SOURCES[DEFAULT_APP_SOURCE])
         self._hass = hass
         self._session = async_get_clientsession(hass)
 
@@ -291,11 +303,11 @@ class HaierClient:
 
         return {
             'accessToken': self._token,
-            'appId': APP_ID,
-            'appKey': APP_KEY,
+            'appId': self._app_id,
+            'appKey': self._app_key,
             'clientId': self._client_id,
             'sequenceId': sequence_id,
-            'sign': self._sign(APP_ID, APP_KEY, timestamp, body, api),
+            'sign': self._sign(self._app_id, self._app_key, timestamp, body, api),
             'timestamp': timestamp,
             'timezone': '+8',
             'language': 'zh-CN'

--- a/custom_components/haier/core/config.py
+++ b/custom_components/haier/core/config.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from custom_components.haier.const import FILTER_TYPE_EXCLUDE, FILTER_TYPE_INCLUDE
+from custom_components.haier.core.client import DEFAULT_APP_SOURCE
 
 
 class AccountConfig:
@@ -20,6 +21,9 @@ class AccountConfig:
 
     expires_at: int = None
 
+    # token来源客户端，决定请求使用的appId/appKey，须与token的来源客户端一致
+    app_source: str = None
+
     default_load_all_entity: bool = None
 
     # 是否忽略设备离线状态。为True时设备离线不会将实体标记为不可用，而是保留最后一次的状态
@@ -34,6 +38,7 @@ class AccountConfig:
         self.token = cfg.get('token', '')
         self.refresh_token = cfg.get('refresh_token', '')
         self.expires_at = cfg.get('expires_at', 0)
+        self.app_source = cfg.get('app_source', DEFAULT_APP_SOURCE)
         self.default_load_all_entity = cfg.get('default_load_all_entity', True)
         self.ignore_device_offline = cfg.get('ignore_device_offline', False)
 
@@ -48,6 +53,7 @@ class AccountConfig:
                     'token': self.token,
                     'refresh_token': self.refresh_token,
                     'expires_at': self.expires_at,
+                    'app_source': self.app_source,
                     'default_load_all_entity': self.default_load_all_entity,
                     'ignore_device_offline': self.ignore_device_offline
                 }

--- a/custom_components/haier/strings.json
+++ b/custom_components/haier/strings.json
@@ -8,6 +8,7 @@
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
+                    "app_source": "Token source",
                     "default_load_all_entity": "Default load all entity",
                     "ignore_device_offline": "Ignore device offline status (keep last state when offline)"
                 },
@@ -33,6 +34,7 @@
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
+                    "app_source": "Token source",
                     "default_load_all_entity": "Default load all entity",
                     "ignore_device_offline": "Ignore device offline status (keep last state when offline)"
                 }

--- a/custom_components/haier/translations/en.json
+++ b/custom_components/haier/translations/en.json
@@ -8,6 +8,7 @@
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
+                    "app_source": "Token source",
                     "default_load_all_entity": "Default load all entity",
                     "ignore_device_offline": "Ignore device offline status (keep last state when offline)"
                 },
@@ -33,6 +34,7 @@
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
+                    "app_source": "Token source",
                     "default_load_all_entity": "Default load all entity",
                     "ignore_device_offline": "Ignore device offline status (keep last state when offline)"
                 }

--- a/custom_components/haier/translations/zh-Hans.json
+++ b/custom_components/haier/translations/zh-Hans.json
@@ -10,6 +10,7 @@
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
+                    "app_source": "Token来源",
                     "default_load_all_entity": "默认加载所有实体",
                     "ignore_device_offline": "忽略设备离线状态（离线时保留最后状态）"
                 }
@@ -33,6 +34,7 @@
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
+                    "app_source": "Token来源",
                     "default_load_all_entity": "默认加载所有实体",
                     "ignore_device_offline": "忽略设备离线状态（离线时保留最后状态）"
                 }


### PR DESCRIPTION
## 问题

`refresh_token` 与签发它的 `appId` 绑定。集成在 `core/client.py` 里硬编码了微信小程序的身份：

```python
APP_ID = 'MB-SHEZJAPPWXXCX-0000'
APP_KEY = '79ce99cc7f9804663939676031b8a427'
```

若手上的 `Client Id` / `Refresh Token` 来自 App（appId 为 `MB-UZHSH-0001`），配置时会失败：

```
WARNING (MainThread) [custom_components.haier.config_flow] 接口返回异常: 授权异常或失败
```

对应 `oauthserver/account/v1/refreshToken` 返回 `retCode 43005`。这个错误码在两种情形下完全一样——传一个无效的 refreshToken 同样返回 43005——所以仅凭日志分辨不出是 token 失效还是来源不匹配，比较难排查。

## 改动

把 appId/appKey 从模块常量改为按配置项 `Token来源` 选择：

```python
APP_SOURCES = {
    APP_SOURCE_WXAPP: ('MB-SHEZJAPPWXXCX-0000', '79ce99cc7f9804663939676031b8a427'),  # 微信小程序
    APP_SOURCE_APP:   ('MB-UZHSH-0001',         '5dfca8714eb26e3a776e58a8273c8752'),  # App
}
```

- `HaierClient.__init__` 新增 `app_source` 参数，默认 `wxapp`，签名与请求头改用实例上的 appId/appKey；
- `AccountConfig` 增加 `app_source` 字段，`cfg.get('app_source', DEFAULT_APP_SOURCE)` 读取；
- 配置流程与「更新账户」选项各加一个下拉框；
- 三份翻译加 `app_source` 标签。

**向后兼容**：默认值仍是微信小程序，已有配置项里没有 `app_source` 时回退到该默认值，行为与改动前完全一致。

## 验证

实测两种身份在集成用到的四个接口上的返回：

| 接口 | 小程序身份 | App 身份 |
|---|---|---|
| `oauthserver/account/v1/refreshToken` | 43005 授权异常 | **00000** |
| `uds/v1/protected/deviceinfos` | 00000 | 00000 |
| `gmsWS/wsag/assign` | 00000 | 00000 |
| `shadow/v1/devdigitalmodels` | 00000 | 00000 |

只有刷新接口校验 appId，其余三个两种身份通用，所以切换来源不影响设备获取、网关分配和物模型查询。

另外确认了 `_sign` 的算法对 App 来源同样成立——用 `sha256(path+query + body + appId + appKey + timestamp)` 复算 App 的 37 个请求，签名全部一致，无需为新来源改签名逻辑。

已在本地 HA 用 App 来源的凭据配置成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
