### PR TITLE
feat: 新增手机号+密码登录方式

### DIFF
--- a/custom_components/haier/config_flow.py
+++ b/custom_components/haier/config_flow.py
@@ -27,6 +27,13 @@ class HaierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 2
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """选择登录方式"""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=['manual', 'phone_login']
+        )
+
+    async def async_step_manual(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: Dict[str, str] = {}
         if user_input is not None:
             try:
@@ -53,7 +60,7 @@ class HaierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors['base'] = 'auth_error'
 
         return self.async_show_form(
-            step_id="user",
+            step_id="manual",
             data_schema=vol.Schema(
                 {
                     vol.Required(CLIENT_ID): str,
@@ -61,6 +68,45 @@ class HaierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(APP_SOURCE, default=DEFAULT_APP_SOURCE): vol.In(APP_SOURCE_OPTIONS),
                     vol.Required('default_load_all_entity', default=True): bool,
                     vol.Required('ignore_device_offline', default=False): bool,
+                }
+            ),
+            errors=errors
+        )
+
+    async def async_step_phone_login(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """手机号+密码登录"""
+        errors: Dict[str, str] = {}
+        if user_input is not None:
+            try:
+                phone = user_input['phone']
+                # 手机号登录使用 App 来源
+                client = HaierClient(self.hass, phone, '', APP_SOURCE_APP)
+                token_info = await client.phone_login(phone, user_input['password'])
+                # 获取用户信息
+                client = HaierClient(self.hass, phone, token_info.token, APP_SOURCE_APP)
+                user_info = await client.get_user_info()
+
+                return self.async_create_entry(title="Haier - {}".format(user_info['mobile']), data={
+                    'account': {
+                        'client_id': phone,
+                        'token': token_info.token,
+                        'refresh_token': token_info.refresh_token,
+                        'expires_at': int(time.time()) + token_info.expires_in,
+                        'app_source': APP_SOURCE_APP,
+                        'default_load_all_entity': True,
+                        'ignore_device_offline': False
+                    }
+                })
+            except HaierClientException as e:
+                _LOGGER.warning(str(e))
+                errors['base'] = 'auth_error'
+
+        return self.async_show_form(
+            step_id="phone_login",
+            data_schema=vol.Schema(
+                {
+                    vol.Required('phone'): str,
+                    vol.Required('password'): str,
                 }
             ),
             errors=errors

--- a/custom_components/haier/core/client.py
+++ b/custom_components/haier/core/client.py
@@ -32,6 +32,7 @@ APP_SOURCES = {
 }
 
 REFRESH_TOKEN_API = 'https://zj.haier.net/api-gw/oauthserver/account/v1/refreshToken'
+PHONE_LOGIN_API = 'https://zj.haier.net/api-gw/oauthserver/account/v1/login'
 GET_USER_INFO_API = 'https://account-api.haier.net/v2/haier/userinfo'
 GET_DEVICES_API = 'https://uws.haier.net/uds/v1/protected/deviceinfos'
 GET_WSS_GW_API = 'https://uws.haier.net/gmsWS/wsag/assign'
@@ -107,6 +108,31 @@ class HaierClient:
         self._app_id, self._app_key = APP_SOURCES.get(app_source, APP_SOURCES[DEFAULT_APP_SOURCE])
         self._hass = hass
         self._session = async_get_clientsession(hass)
+
+    @retry_on_exception(exceptions=(aiohttp.ClientError, asyncio.TimeoutError))
+    async def phone_login(self, phone: str, password: str) -> TokenInfo:
+        """
+        手机号+密码登录（使用 App 来源的 appId/appKey）
+        :param phone: 手机号
+        :param password: 密码
+        :return: TokenInfo
+        """
+        payload = {
+            'username': phone,
+            'password': password
+        }
+
+        headers = await self._generate_common_headers(PHONE_LOGIN_API, json.dumps(payload))
+        async with self._session.post(url=PHONE_LOGIN_API, headers=headers, json=payload) as response:
+            content = await response.json(content_type=None)
+            self._assert_response_successful(content)
+
+            token_info = content['data']['tokenInfo']
+            return TokenInfo(
+                token_info['accountToken'],
+                token_info['refreshToken'],
+                token_info['expiresIn']
+            )
 
     @retry_on_exception(exceptions=(aiohttp.ClientError, asyncio.TimeoutError))
     async def refresh_token(self, refresh_token: str) -> TokenInfo:

--- a/custom_components/haier/strings.json
+++ b/custom_components/haier/strings.json
@@ -5,6 +5,12 @@
         },
         "step": {
             "user": {
+                "menu_options": {
+                    "manual": "Manual (enter refresh_token)",
+                    "phone_login": "Phone number login"
+                }
+            },
+            "manual": {
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
@@ -12,8 +18,16 @@
                     "default_load_all_entity": "Default load all entity",
                     "ignore_device_offline": "Ignore device offline status (keep last state when offline)"
                 },
-                "description": "Enter your Haier Token.",
+                "description": "Enter your Haier refresh_token.",
                 "title": "Configure account information"
+            },
+            "phone_login": {
+                "title": "Phone number login",
+                "description": "Login with your Haier account phone number and password.",
+                "data": {
+                    "phone": "Phone number",
+                    "password": "Password"
+                }
             }
         }
     },

--- a/custom_components/haier/translations/en.json
+++ b/custom_components/haier/translations/en.json
@@ -5,6 +5,12 @@
         },
         "step": {
             "user": {
+                "menu_options": {
+                    "manual": "Manual (enter refresh_token)",
+                    "phone_login": "Phone number login"
+                }
+            },
+            "manual": {
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
@@ -12,8 +18,16 @@
                     "default_load_all_entity": "Default load all entity",
                     "ignore_device_offline": "Ignore device offline status (keep last state when offline)"
                 },
-                "description": "Enter your Haier Token.",
+                "description": "Enter your Haier refresh_token.",
                 "title": "Configure account information"
+            },
+            "phone_login": {
+                "title": "Phone number login",
+                "description": "Login with your Haier account phone number and password.",
+                "data": {
+                    "phone": "Phone number",
+                    "password": "Password"
+                }
             }
         }
     },

--- a/custom_components/haier/translations/zh-Hans.json
+++ b/custom_components/haier/translations/zh-Hans.json
@@ -5,14 +5,28 @@
         },
         "step": {
             "user": {
+                "menu_options": {
+                    "manual": "手动输入 refresh_token",
+                    "phone_login": "手机号登录"
+                }
+            },
+            "manual": {
                 "title": "账号设置",
-                "description": "配置海尔智家账户",
+                "description": "手动输入海尔 refresh_token 配置账户",
                 "data": {
                     "client_id": "Client Id",
                     "refresh_token": "Refresh Token",
                     "app_source": "Token来源",
                     "default_load_all_entity": "默认加载所有实体",
                     "ignore_device_offline": "忽略设备离线状态（离线时保留最后状态）"
+                }
+            },
+            "phone_login": {
+                "title": "手机号登录",
+                "description": "使用海尔智家账号手机号和密码登录",
+                "data": {
+                    "phone": "手机号",
+                    "password": "密码"
                 }
             }
         }


### PR DESCRIPTION
## 概述
为海尔智家集成新增「手机号 + 密码」登录方式，用户在添加集成时可通过菜单选择：
- **手动输入 refresh_token**（原有方式，保留）
- **手机号登录**（新增，免抓包）

## 改动内容
- `core/client.py`：新增 `PHONE_LOGIN_API` 常量与 `phone_login(phone, password)` 方法，沿用现有签名/重试机制。
- `config_flow.py`：登录入口 `async_step_user` 改为菜单，拆分为 `async_step_manual` 与 `async_step_phone_login`。手机登录固定使用 `APP_SOURCE_APP` 来源（App 的 appId/appKey），与 refresh_token 绑定的来源一致，避免刷新时报 43005。
- 翻译文件 `strings.json` / `translations/en.json` / `translations/zh-Hans.json`：补充 `user` 菜单、`manual`、`phone_login` 步骤文案（中英文）。

## 适配说明
已基于上游最新的 `app_source` 可选架构实现，手机登录写入的 `app_source: app` 会贯穿 `AccountConfig` 存储、`__init__` 建连与 `token_updater` 刷新，保证后续接口与 WebSocket 网关使用正确的 appId/appKey。

## 测试
- 两个 Python 文件通过 `py_compile` 语法检查
- 三个翻译文件 JSON 合法且步骤/字段键完全一致
- 登录流程 schema 字段（`phone`/`password`、`app_source` 等）与翻译键一一对应

## 兼容性
- 不破坏现有手动 refresh_token 登录路径

🤖 Generated with WorkBuddy