### PR TITLE
fix: 燃气热水器温度范围转为数字，修复实体注册失败

### DIFF
--- a/custom_components/haier/core/attribute.py
+++ b/custom_components/haier/core/attribute.py
@@ -214,10 +214,11 @@ class V1SpecAttributeParser(HaierAttributeParser, ABC):
         else:
             raise RuntimeError('targetTemp attr not found')
 
+        data_step = target_temperature_attr['valueRange']['dataStep']
         options = {
-            'min_temp': target_temperature_attr['valueRange']['dataStep']['minValue'],
-            'max_temp': target_temperature_attr['valueRange']['dataStep']['maxValue'],
-            'target_temperature_step': target_temperature_attr['valueRange']['dataStep']['step']
+            'min_temp': float(data_step['minValue']),
+            'max_temp': float(data_step['maxValue']),
+            'target_temperature_step': float(data_step['step'])
         }
 
         ext = {


### PR DESCRIPTION
Fixes #282
接口返回的 dataStep 中 minValue/maxValue/step 均为字符串，经entity.py 的 setattr 直接赋给 _attr_min_temp 等属性后，HA 的display_temp() 因非数字类型抛出 TypeError，导致 water_heater实体注册失败、状态变为 unavailable。