### PR TITLE
feat: support remote program selection for dryers via drycycle select

### DIFF
--- a/custom_components/haier/core/attribute.py
+++ b/custom_components/haier/core/attribute.py
@@ -96,7 +96,8 @@ class V1SpecAttributeParser(HaierAttributeParser, ABC):
 
         # 洗碗机/洗衣机：对只读LIST类型的洗涤模式属性，保留原Sensor作为状态读取，
         # 同时额外生成Select实体用于在HA中切换模式
-        _control_attrs = {'washprog', 'partitionwashstatus', 'runningmode'}
+        # 干衣机：drycycle(干燥程序)固件实际接受写入（含一键智烘），据此生成Select支持远程选程序
+        _control_attrs = {'washprog', 'partitionwashstatus', 'runningmode', 'drycycle'}
         for attr in attributes:
             if attr['name'].lower() in _control_attrs \
                     and equals_ignore_case(attr['valueRange']['type'], 'LIST'):


### PR DESCRIPTION
## What

Add `drycycle` to `_control_attrs`, so dryers get an extra writable Select entity for 干燨程序 (dry cycle) — the same mechanism already used for washer/dishwasher wash modes (`washprog`, `partitionwashstatus`, `runningmode`).

## Why

The cloud spec declares `dryCycle` read-only, but dryer firmware actually accepts writes — exactly like `runningMode`. Verified end-to-end on **HGY100-F376WU1** (干衣机):

1. Select 一键智烘 (`drycycle=43`) → `localProgName1=OneKeyDry`, `dryCycle` sensor reports 一键智烘, value retained (no rollback)
2. Select 启动 (`runningMode`) → cycle starts, `cyclePhase=自动判断负载中`

This enables full remote/voice program selection (all 24 programs incl. OneKeyDry), instead of only switching `programClass`.

## Notes

- The extra Select is generated alongside the original read-only sensor; `data_key` remains `drycycle`.
- Firmware ignores program writes mid-cycle (expected), so selection happens between power-on and start.
