### PR TITLE
fix: expose one-way boolean commands as buttons

### DIFF
--- a/custom_components/haier/button.py
+++ b/custom_components/haier/button.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from . import async_register_entity
+from .core.attribute import HaierAttribute
+from .core.device import HaierDevice
+from .entity import HaierAbstractEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    await async_register_entity(
+        hass,
+        entry,
+        async_add_entities,
+        Platform.BUTTON,
+        lambda device, attribute: HaierButton(device, attribute)
+    )
+
+
+class HaierButton(HaierAbstractEntity, ButtonEntity):
+
+    def __init__(self, device: HaierDevice, attribute: HaierAttribute):
+        super().__init__(device, attribute)
+
+    def _update_value(self):
+        # A button has no persistent value.  The base entity still uses each
+        # incoming snapshot to mark the command available.
+        return None
+
+    def press(self, **kwargs: Any) -> None:
+        self._send_command({
+            self._attribute.key: self._attribute.ext['command_value']
+        })

--- a/custom_components/haier/const.py
+++ b/custom_components/haier/const.py
@@ -12,7 +12,8 @@ SUPPORTED_PLATFORMS = [
     Platform.SWITCH,
     Platform.CLIMATE,
     Platform.WATER_HEATER,
-    Platform.COVER
+    Platform.COVER,
+    Platform.BUTTON,
 ]
 
 FILTER_TYPE_INCLUDE = 'include'

--- a/custom_components/haier/core/attribute.py
+++ b/custom_components/haier/core/attribute.py
@@ -63,6 +63,14 @@ class V1SpecAttributeParser(HaierAttributeParser, ABC):
         if attribute['writable'] and equals_ignore_case(attribute['valueRange']['type'], 'STEP') and contains_any_ignore_case(attribute['valueRange']['dataStep']['dataType'], ['Integer', 'Double']):
             return self._parse_as_number(attribute)
 
+        # One-way boolean commands (for example the refrigerator's forced
+        # sterilization actions) are represented by a one-item LIST.  They are
+        # not selects: the returned false value means "not currently firing"
+        # and is not one of the selectable options.  Expose them as buttons so
+        # HA never presents an invalid current option or a misleading toggle.
+        if attribute['writable'] and V1SpecAttributeParser._is_one_way_boolean_command(attribute):
+            return self._parse_as_button(attribute)
+
         # 一定要在select之前，不然会被select覆盖
         if attribute['writable'] and V1SpecAttributeParser._is_binary_attribute(attribute):
             return self._parse_as_switch(attribute)
@@ -182,6 +190,26 @@ class V1SpecAttributeParser(HaierAttributeParser, ABC):
         }
 
         return HaierAttribute(attribute['name'], attribute['desc'], Platform.SWITCH, options)
+
+    @staticmethod
+    def _parse_as_button(attribute):
+        item = attribute['valueRange']['dataList'][0]
+        return HaierAttribute(
+            attribute['name'],
+            attribute['desc'],
+            Platform.BUTTON,
+            ext={'command_value': item['data']}
+        )
+
+    @staticmethod
+    def _is_one_way_boolean_command(attribute):
+        value_range = attribute.get('valueRange', {})
+        data_list = value_range.get('dataList', [])
+        return (
+            equals_ignore_case(value_range.get('type'), 'LIST')
+            and len(data_list) == 1
+            and str(data_list[0].get('data')).lower() in ('true', 'false')
+        )
 
     @staticmethod
     def _parse_as_climate(attributes: List[dict], feature_fields: List[str]):


### PR DESCRIPTION
## Problem

Some Haier devices expose one-way boolean commands as a `LIST` with a single item. The refrigerator fields `refSterilizationForcedOn` and `refSterilizationForcedOff` return `false` after the command is idle, while their only selectable value is `true`/`开`. The current parser creates a `select`, so Home Assistant receives an invalid current option and logs repeated `value not recognizable` warnings.

## Fix

- Detect one-item boolean LIST commands before normal select parsing.
- Expose them as stateless Home Assistant `button` entities.
- Preserve the vendor-provided command value when `button.press` sends the command.
- Keep ordinary two-value boolean LIST attributes as switches and all other LIST attributes as selects.

## Verification

- Home Assistant `2026.9.1` amd64 container: all changed modules import successfully.
- Synthetic parser/entity test: one-item boolean -> button; two-item boolean -> switch; button press payload preserves vendor value.
- No real sterilization command was sent. Hardware/API behavior remains to be verified by the maintainer or an opt-in user test.

Target observed fields: `refSterilizationForcedOn`, `refSterilizationForcedOff`.
